### PR TITLE
Some QOL things

### DIFF
--- a/Editor/GameObjectPropertyDrawer.cs
+++ b/Editor/GameObjectPropertyDrawer.cs
@@ -74,7 +74,7 @@ public class GameObjectPropertyDrawer: PropertyDrawer {
         property.objectReferenceValue = EditorGUI.ObjectField(new Rect(position.x, position.y, position.width - position.height, position.height), label, property.objectReferenceValue, fieldInfo.FieldType, true);
         var pickerRect = new Rect(position.x + position.width - position.height, position.y, position.height, position.height);
 		var oldColor = GUI.backgroundColor;
-		if(GameObjectPropertyDrawerUtils.pickedDrawerID == GameObjectPropertyDrawerUtils.currentPropertyDrawerID) {
+		if(GameObjectPropertyDrawerUtils.pickedDrawer == this) {
 			GUI.backgroundColor = Color.cyan;
 		}
         if (GUI.Button(pickerRect, new GUIContent("","Pick object from the scene view"))) {


### PR DESCRIPTION
Quality of life updates.

**Changes on 26:** should cancel the picking if the user clicks any other mouse button other than left.

**Changes on 63:** Added check to prevent self-referencing picking

**Changes on 74:** Main one! Replaced hardcoding of GameObject type to the actual type of the property field. So now by just adding more `[CustomPropertyDrawer(typeof( ))]` to the class it is possible to add those pickers to any field type that deals with picking game objects or MonoBehaviors on the objects.

**Changes on 76:** Added condition that will change the button's color to indicate it's in "pick object" mode.

**Changes on 80:** Just added a helpful tooltip.